### PR TITLE
docs: expand README with overview and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,58 @@
-`sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"`
+# TradeOS Contracts
 
-`npm i -g pnpm ic-mops`
+## Overview
 
-`pnpm i`
+TradeOS is a decentralized policy engine composed of modular smart
+contracts. The platform emphasizes configurability so that different
+trading scenarios can plug in without rewriting the entire system. By
+leveraging a fully decentralized architecture, no single entity can
+unilaterally control or censor trades. The engine coordinates with
+multichain vaults to escrow assets securely and accepts multiple trust
+mechanisms—such as zkTLS or TEE‑TLS—to verify delivery proofs or dispute
+evidence. A domain‑specific language, **TPL (TradeOS Policy Language)**,
+allows traders to script custom policies while still benefiting from
+community‑maintained templates for common P2P flows. By unifying multiple
+blockchains and user bases, TradeOS aims to share liquidity globally and
+enable cross‑chain commerce at scale.
 
-`mops i`
+## Guarantee Canister & API
 
-`modify file dfx.json - canisters.guarantee.controllers`
+This repository contains an Express server (`server.ts`) that interfaces
+with the `guarantee` canister. The server exposes a REST API for managing
+escrow transactions and related actions:
 
-`dfx start --background`
+- `POST /initialize` – start an escrow transaction
+- `POST /confirmStaking` – record staking completion for each participant
+- `POST /confirmTrading` – confirm delivery of trade goods or services
+- `POST /confirmSettling` – finalize payouts once conditions are met
+- `POST /initiateDispute` – begin a dispute with cryptographic evidence
+- `POST /resolveDispute` – resolve a dispute and specify custom
+  settlements
+- `POST /signWithSchnorr` – obtain a Schnorr signature for settlement
+- `GET /schnorrPublicKey` – fetch the signing public key
+- `GET /signWithSchnorrContent/:id` – view the payload used for signing
+- `GET /canisterPrincipal` – return the canister principal text
+- `GET /transaction/:id` – inspect transaction details
+- `GET /proof/:id` – retrieve any attached proof for a transaction
 
-`pnpm deploy:local`
+The accompanying test suite (`tests/guarantee.test.ts`) demonstrates
+basic trade lifecycles, signature verification, dispute handling, and
+utility helpers for querying transaction history.
 
-`pnpm test:guarantee`
+## Setup
 
-`cp .env.example .env` # then edit values including `IDENTITY_JSON_PATH`
+Follow these steps to run the project locally:
 
-`pnpm start`
+1. `sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"`
+2. `npm i -g pnpm ic-mops`
+3. `pnpm i`
+4. `mops i`
+5. `modify file dfx.json - canisters.guarantee.controllers`
+6. `dfx start --background`
+7. `pnpm deploy:local`
+8. `pnpm test:guarantee`
+9. `cp .env.example .env` # then edit values including `IDENTITY_JSON_PATH`
+10. `pnpm start`
+11. Use the `/setGlobalConfig` endpoint to set `proofUrl`, `proofCycles`,
+    `schnorrKeyID`, and `schnorrCycles` after deploying to mainnet.
 
-Use the `/setGlobalConfig` endpoint to set `proofUrl`, `proofCycles`,
-`schnorrKeyID`, and `schnorrCycles` after deploying to mainnet.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# TradeOS Contracts
+# TradeOS Decentralized Policy Engine
 
 ## Overview
 
-TradeOS is a decentralized policy engine composed of modular smart
-contracts. The platform emphasizes configurability so that different
-trading scenarios can plug in without rewriting the entire system. By
+At the heart of TradeOS is a collection of smart contracts designed to be 
+modular and configurable, allowing different trading scenarios and 
+requirements to plug in without rewriting the entire system. By
 leveraging a fully decentralized architecture, no single entity can
 unilaterally control or censor trades. The engine coordinates with
 multichain vaults to escrow assets securely and accepts multiple trust
-mechanisms—such as zkTLS or TEE‑TLS—to verify delivery proofs or dispute
-evidence. A domain‑specific language, **TPL (TradeOS Policy Language)**,
+mechanisms -- such as zkTLS or TEE‑TLS -- to verify delivery proofs or 
+dispute evidence. A domain‑specific language, **TPL (TradeOS Policy Language)**,
 allows traders to script custom policies while still benefiting from
 community‑maintained templates for common P2P flows. By unifying multiple
 blockchains and user bases, TradeOS aims to share liquidity globally and
 enable cross‑chain commerce at scale.
 
-## Guarantee Canister & API
+## Escrow Payment Canister & APIs
 
 This repository contains an Express server (`server.ts`) that interfaces
-with the `guarantee` canister. The server exposes a REST API for managing
+with the escrow payment canister. The server exposes a REST API for managing
 escrow transactions and related actions:
 
 - `POST /initialize` – start an escrow transaction
@@ -31,9 +31,9 @@ escrow transactions and related actions:
 - `POST /signWithSchnorr` – obtain a Schnorr signature for settlement
 - `GET /schnorrPublicKey` – fetch the signing public key
 - `GET /signWithSchnorrContent/:id` – view the payload used for signing
-- `GET /canisterPrincipal` – return the canister principal text
 - `GET /transaction/:id` – inspect transaction details
 - `GET /proof/:id` – retrieve any attached proof for a transaction
+- `GET /canisterPrincipal` – return the canister principal text
 
 The accompanying test suite (`tests/guarantee.test.ts`) demonstrates
 basic trade lifecycles, signature verification, dispute handling, and


### PR DESCRIPTION
## Summary
- add an overview of TradeOS and its decentralized policy engine
- document guarantee canister API endpoints and test coverage
- restructure README with setup instructions and mainnet configuration notes

## Testing
- `pnpm test:guarantee` *(fails: Cannot find module '../.dfx/local/canisters/guarantee/service.did.js')*


------
https://chatgpt.com/codex/tasks/task_e_689ca7d21bac83318d2aa0ab859bfa5d